### PR TITLE
If ExternalProcess has OutputFileToken, check that it actually writes…

### DIFF
--- a/src/main/scala/org/allenai/pipeline/ExternalProcess.scala
+++ b/src/main/scala/org/allenai/pipeline/ExternalProcess.scala
@@ -67,6 +67,17 @@ class ExternalProcess(val commandTokens: CommandToken*) {
     out.close()
     err.close()
 
+    commandTokens.foreach {
+      case OutputFileToken(name) =>
+        val fOut = new File(scratchDir, name)
+        if(!fOut.exists()) {
+          val stCmd = cmd.mkString(" ")
+          throw new RuntimeException(
+            f"Script should have written an output file at:${fOut.getCanonicalPath}\n  command=$stCmd")
+        }
+      case _ =>
+    }
+
     val outputNames = commandTokens.collect { case OutputFileToken(name) => name }
 
     val outputStreams = for (name <- outputNames) yield {


### PR DESCRIPTION
If ExternalProcess has OutputFileToken, check that it actually writes something.
Save newbies from this horrific call stack:

```
    6435     ERROR org.allenai.pipeline.Pipeline$$anon$1 [run-main-0] Untrapped exception
    java.io.FileNotFoundException: /var/folders/4j/7wz0c3gx7vgb340h0nf2cjsc0000gn/T/9174563377670596194/output (No such file or directory)
        at java.io.FileInputStream.open(Native Method)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at org.allenai.pipeline.FileArtifact.read(FileArtifact.scala:22)
        at org.allenai.pipeline.StreamIo$$anonfun$read$1.apply(ExternalProcess.scala:182)
        at org.allenai.pipeline.StreamIo$$anonfun$read$1.apply(ExternalProcess.scala:182)
        at org.allenai.pipeline.StreamIo$$anonfun$write$1.apply(ExternalProcess.scala:187)
        at org.allenai.pipeline.StreamIo$$anonfun$write$1.apply(ExternalProcess.scala:185)
        at org.allenai.pipeline.FileArtifact.write(FileArtifact.scala:31)
        at org.allenai.pipeline.StreamIo$.write(ExternalProcess.scala:185)
        at org.allenai.pipeline.StreamIo$.write(ExternalProcess.scala:180)
        at org.allenai.pipeline.ProducerWithPersistence.create(Producer.scala:180)
        at org.allenai.pipeline.Producer$$anonfun$7.apply(Producer.scala:64)
        at org.allenai.common.Timing$.time(Timing.scala:19)
        at org.allenai.pipeline.Producer$class.createAndTime(Producer.scala:64)
        at org.allenai.pipeline.ProducerWithPersistence.createAndTime(Producer.scala:167)
        at org.allenai.pipeline.Producer$class.org$allenai$pipeline$Producer$$cachedValue(Producer.scala:54)
        at org.allenai.pipeline.ProducerWithPersistence.org$allenai$pipeline$Producer$$cachedValue$lzycompute(Producer.scala:167)
        at org.allenai.pipeline.ProducerWithPersistence.org$allenai$pipeline$Producer$$cachedValue(Producer.scala:167)
        at org.allenai.pipeline.Producer$class.get(Producer.scala:39)
        at org.allenai.pipeline.ProducerWithPersistence.get(Producer.scala:167)
        at org.allenai.pipeline.Pipeline$$anonfun$14.apply(Pipeline.scala:152)
        at org.allenai.pipeline.Pipeline$$anonfun$14.apply(Pipeline.scala:152)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
        at scala.collection.immutable.List.foreach(List.scala:381)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:245)
        at scala.collection.immutable.List.map(List.scala:285)
        at org.allenai.pipeline.Pipeline.runPipelineReturnResults(Pipeline.scala:152)
        at org.allenai.pipeline.Pipeline.run(Pipeline.scala:25)
```
