### PR TITLE
bug repro: add failing unit test

### DIFF
--- a/core/src/test/scala/org/allenai/pipeline/TestExternalProcess.scala
+++ b/core/src/test/scala/org/allenai/pipeline/TestExternalProcess.scala
@@ -87,7 +87,7 @@ class TestExternalProcess extends UnitSpec with ScratchDirectory {
   }
 
   it should "capture stdout newlines" in {
-    val s = "An old silent pond...\nA frog jumps into the pond,\nsplash! Silence again.\n"
+    val s = "An old silent pond...\\nA frog jumps into the pond,\\nsplash! Silence again.\\n"
     val echo = new ExternalProcess("printf", s)
     val cLines = IOUtils.readLines(echo.run(Map()).stdout()).asScala.count(_ => true)
     cLines should equal(3)

--- a/core/src/test/scala/org/allenai/pipeline/TestExternalProcess.scala
+++ b/core/src/test/scala/org/allenai/pipeline/TestExternalProcess.scala
@@ -85,6 +85,14 @@ class TestExternalProcess extends UnitSpec with ScratchDirectory {
     val stdout = IOUtils.readLines(echo.run().stdout()).asScala.mkString("\n")
     stdout should equal("hello world")
   }
+
+  it should "capture stdout newlines" in {
+    val s = "An old silent pond...\nA frog jumps into the pond,\nsplash! Silence again.\n"
+    val echo = new ExternalProcess("printf", s)
+    val cLines = IOUtils.readLines(echo.run(Map()).stdout()).asScala.count(_ => true)
+    cLines should equal(3)
+  }
+
   it should "capture stderr" in {
     val noSuchParameter = new ExternalProcess("touch", "-x", "foo")
     val stderr = IOUtils.readLines(noSuchParameter.run().stderr()).asScala.mkString("\n")


### PR DESCRIPTION
ExternalProcess stdout and stderr are not capturing newlines.  Here is a failing unit test to demonstrate.
